### PR TITLE
Bump dependencies and fix tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,18 +23,20 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest]
         
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
         
     - name: Run unit tests and collect coverage
       run: dotnet test --collect "XPlat Code Coverage" --logger GitHubActions --verbosity normal
 
-    - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v3
+    - if: matrix.os == 'ubuntu-latest'
+      name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v4
       with:
-        directory: Instances.Tests/TestResults
         fail_ci_if_error: true
+        directory: Instances.Tests/TestResults
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/Instances.Tests.WaitingProgram/Instances.Tests.WaitingProgram.csproj
+++ b/Instances.Tests.WaitingProgram/Instances.Tests.WaitingProgram.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/Instances.Tests/Instances.Tests.csproj
+++ b/Instances.Tests/Instances.Tests.csproj
@@ -1,22 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="3.1.2">
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="GitHubActionsTestLogger" Version="1.3.0">
+        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="NUnit" Version="3.13.2" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="NUnit" Version="4.2.2" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Instances.Tests/Tests.cs
+++ b/Instances.Tests/Tests.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Instances.Exceptions;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Instances.Tests
 {
@@ -18,40 +19,39 @@ namespace Instances.Tests
 
             arguments.Start();
             var result = completionSource.Task.GetAwaiter().GetResult();
-            
-            Assert.NotZero(result.ExitCode);
+            Assert.That(result.ExitCode, Is.Not.EqualTo(0));
         }
         [Test]
         public void StaticFinishSuccessTest()
         {
             var outputReceived = false;
             var processResult = Instance.Finish("dotnet", "--list-runtimes", delegate { outputReceived = true; });
-            Assert.AreEqual(true, outputReceived);
-            Assert.Zero(processResult.ExitCode);
+            Assert.That(outputReceived, Is.True);
+            Assert.That(processResult.ExitCode, Is.EqualTo(0));
         }
         [Test]
         public void StaticFinishErrorTest()
         {
             var outputReceived = false;
             var processResult = Instance.Finish("dotnet", "run --project Nopes", delegate { outputReceived = true; });
-            Assert.AreEqual(true, outputReceived);
-            Assert.NotZero(processResult.ExitCode);
+            Assert.That(outputReceived, Is.True);
+            Assert.That(processResult.ExitCode, Is.Not.EqualTo(0));
         }
         [Test]
         public async Task AsyncStaticFinishSuccessTest()
         {
             var outputReceived = false;
             var processResult = await Instance.FinishAsync("dotnet", "--list-runtimes", default, delegate { outputReceived = true; });
-            Assert.AreEqual(true, outputReceived);
-            Assert.Zero(processResult.ExitCode);
+            Assert.That(outputReceived, Is.True);
+            Assert.That(processResult.ExitCode, Is.EqualTo(0));
         }
         [Test]
         public async Task AsyncStaticFinishErrorTest()
         {
             var outputReceived = false;
             var processResult = await Instance.FinishAsync("dotnet", "run --project Nopes", default, delegate { outputReceived = true; });
-            Assert.AreEqual(true, outputReceived);
-            Assert.NotZero(processResult.ExitCode);
+            Assert.That(outputReceived, Is.True);
+            Assert.That(processResult.ExitCode, Is.Not.EqualTo(0));
         }
         [Test]
         public async Task PublishesExitedEventOnSuccess()
@@ -63,7 +63,7 @@ namespace Instances.Tests
             processArguments.Start();
             var result = await completionSource.Task;
             
-            Assert.Zero(result.ExitCode);
+            Assert.That(result.ExitCode, Is.EqualTo(0));
         }
         [Test]
         public void PublishesErrorEvents()
@@ -75,7 +75,7 @@ namespace Instances.Tests
             using var instance = processArguments.Start();
             instance.WaitForExit();
             
-            Assert.IsTrue(dataReceived);
+            Assert.That(dataReceived, Is.True);
         }
         [Test]
         public async Task PublishesDataEvents()
@@ -87,7 +87,7 @@ namespace Instances.Tests
             using var instance = processArguments.Start();
             await instance.WaitForExitAsync();
             
-            Assert.IsTrue(dataReceived);
+            Assert.That(dataReceived, Is.True);
         }
         [Test]
         public async Task IgnoreEmptyLinesWork()
@@ -103,7 +103,7 @@ namespace Instances.Tests
             await instance2.WaitForExitAsync();
             var linesExcludingNewline = instance2.OutputData.Count;
             
-            Assert.Less(linesExcludingNewline, linesIncludingNewline);
+            Assert.That(linesExcludingNewline, Is.LessThan(linesIncludingNewline));
         }
         [Test]
         public void SecondErrorTest()
@@ -112,8 +112,7 @@ namespace Instances.Tests
 
             using var instance = processArguments.Start();
             instance.WaitForExit();
-            
-            Assert.IsTrue(instance.ErrorData.First() == "The build failed. Fix the build errors and run again.");
+            Assert.That(instance.ErrorData.First() == "The build failed. Fix the build errors and run again.", Is.True);
         }
         [Test]
         public void ResultMatchesInstance()
@@ -123,7 +122,7 @@ namespace Instances.Tests
             using var instance = processArguments.Start();
             var result = instance.WaitForExit();
 
-            Assert.Zero(result.ExitCode);
+            Assert.That(result.ExitCode, Is.EqualTo(0));
             CollectionAssert.AreEqual(instance.ErrorData, result.ErrorData);
             CollectionAssert.AreEqual(instance.OutputData, result.OutputData);
         }
@@ -135,7 +134,7 @@ namespace Instances.Tests
             using var instance = processArguments.Start();
             var result = await instance.WaitForExitAsync();
             
-            Assert.NotZero(result.ExitCode);
+            Assert.That(result.ExitCode, Is.Not.EqualTo(0));
             CollectionAssert.IsNotEmpty(instance.ErrorData);
         }
         [Test]
@@ -144,8 +143,8 @@ namespace Instances.Tests
             using var instance = Instance.Start("dotnet", "--help");
             var result = await instance.WaitForExitAsync();
             
-            Assert.Zero(result.ExitCode);
-            Assert.IsTrue(result.OutputData.Any(line => line.Contains("run")));
+            Assert.That(result.ExitCode, Is.EqualTo(0));
+            Assert.That(result.OutputData.Any(line => line.Contains("run")), Is.True);
             CollectionAssert.IsEmpty(instance.ErrorData);
         }
         [Test]
@@ -164,8 +163,8 @@ namespace Instances.Tests
         {
             var processArguments = new ProcessArguments("dotnet", "--help") { DataBufferCapacity = 3 };
             var result = await processArguments.StartAndWaitForExitAsync();
-            Assert.AreEqual(3, result.OutputData.Count);
-            Assert.IsEmpty(result.ErrorData);
+            Assert.That(result.OutputData.Count, Is.EqualTo(3));
+            Assert.That(result.ErrorData, Is.Empty);
         }
 
         [Test]
@@ -177,7 +176,7 @@ namespace Instances.Tests
             });
         }
         
-        [Test, Timeout(10000)]
+        [Test, CancelAfter(10000)]
         public async Task VerifyCancellationStopsProcess()
         {
             var processArguments = GetWaitingProcessArguments();
@@ -189,10 +188,10 @@ namespace Instances.Tests
             await instance.WaitForExitAsync(cancel.Token);
         
             var elapsed = DateTime.UtcNow.Subtract(started).TotalSeconds;
-            Assert.Greater(elapsed, 0.09);
+            Assert.That(elapsed, Is.GreaterThan(0.09));
         }
 
-        [Test, Timeout(10000)]
+        [Test, CancelAfter(10000)]
         public async Task VerifyCancellationAlreadyExitedProcess()
         {
             var processArguments = GetWaitingProcessArguments();
@@ -204,10 +203,10 @@ namespace Instances.Tests
             var result = await instance.WaitForExitAsync(tokenSource.Token);
 
             Assert.DoesNotThrow(() => tokenSource.Cancel());
-            Assert.AreEqual(0, result.ExitCode);
+            Assert.That(result.ExitCode, Is.EqualTo(0));
         }
         
-        [Test, Timeout(10000)]
+        [Test, CancelAfter(10000)]
         public void VerifyKillStopsProcess()
         {
             var processArguments = GetWaitingProcessArguments();
@@ -218,10 +217,10 @@ namespace Instances.Tests
             instance.WaitForExit();
         
             var elapsed = DateTime.UtcNow.Subtract(started).TotalSeconds;
-            Assert.Greater(elapsed, 0.09);
+            Assert.That(elapsed, Is.GreaterThan(0.09));
         }
         
-        [Test, Timeout(10000)]
+        [Test, CancelAfter(10000)]
         public async Task DoubleKillReturnsSameResult()
         {
             var processArguments = GetWaitingProcessArguments();
@@ -231,12 +230,12 @@ namespace Instances.Tests
             var result1 = instance.Kill();
             var result2 = instance.Kill();
             
-            Assert.AreEqual(result1.ExitCode, result2.ExitCode);
+            Assert.That(result1.ExitCode, Is.EqualTo(result2.ExitCode));
             CollectionAssert.AreEqual(result1.OutputData, result2.OutputData);
             CollectionAssert.AreEqual(result1.ErrorData, result2.ErrorData);
         }
         
-        [Test, Timeout(10000)]
+        [Test, CancelAfter(10000)]
         public async Task DoubleWaitForExitReturnsSameResult()
         {
             var processArguments = GetWaitingProcessArguments();
@@ -246,12 +245,12 @@ namespace Instances.Tests
             var result1 = instance.WaitForExit();
             var result2 = instance.WaitForExit();
             
-            Assert.AreEqual(result1.ExitCode, result2.ExitCode);
+            Assert.That(result1.ExitCode, Is.EqualTo(result2.ExitCode));
             CollectionAssert.AreEqual(result1.OutputData, result2.OutputData);
             CollectionAssert.AreEqual(result1.ErrorData, result2.ErrorData);
         }
         
-        [Test, Timeout(10000)]
+        [Test, CancelAfter(10000)]
         public async Task DoubleWaitForExitAsyncReturnsSameResult()
         {
             var processArguments = GetWaitingProcessArguments();
@@ -261,12 +260,12 @@ namespace Instances.Tests
             var result1 = await instance.WaitForExitAsync();
             var result2 = await instance.WaitForExitAsync();
             
-            Assert.AreEqual(result1.ExitCode, result2.ExitCode);
+            Assert.That(result1.ExitCode, Is.EqualTo(result2.ExitCode));
             CollectionAssert.AreEqual(result1.OutputData, result2.OutputData);
             CollectionAssert.AreEqual(result1.ErrorData, result2.ErrorData);
         }
         
-        [Test, Timeout(10000)]
+        [Test, CancelAfter(10000)]
         public async Task VerifySendInputBehaviour()
         {
             var processArguments = GetWaitingProcessArguments();
@@ -278,10 +277,10 @@ namespace Instances.Tests
             await instance.WaitForExitAsync();
         
             var elapsed = DateTime.UtcNow.Subtract(started).TotalSeconds;
-            Assert.Greater(elapsed, 0.09);
+            Assert.That(elapsed, Is.GreaterThan(0.09));
         }
         
-        [Test, Timeout(10000)]
+        [Test, CancelAfter(10000)]
         public async Task VerifySendInputAsyncBehaviour()
         {
             var processArguments = GetWaitingProcessArguments();
@@ -293,7 +292,7 @@ namespace Instances.Tests
             await instance.WaitForExitAsync();
         
             var elapsed = DateTime.UtcNow.Subtract(started).TotalSeconds;
-            Assert.Greater(elapsed, 0.09);
+            Assert.That(elapsed, Is.GreaterThan(0.09));
         }
 
         [OneTimeSetUp]

--- a/Instances/Instances.csproj
+++ b/Instances/Instances.csproj
@@ -13,8 +13,9 @@
         <PackageTags>instances instance process async task events run exec</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageVersion>3.0.0</PackageVersion>
-        <PackageReleaseNotes>Changed behaviour for handling process already exited on Kill, WaitForExit and WaitForExitAsync</PackageReleaseNotes>
+        <PackageVersion>3.0.1</PackageVersion>
+        <PackageReleaseNotes>- Bump dependencies
+- Fix for cancellation cornercase in WaitForExitAsync</PackageReleaseNotes>
         <RepositoryUrl>https://github.com/rosenbjerg/Instances</RepositoryUrl>
     </PropertyGroup>
 


### PR DESCRIPTION
This pull request includes several updates to dependencies, test assertions, and project configurations. The most important changes involve upgrading dependencies in the CI workflow and project files, as well as refactoring test assertions for better readability and maintainability.

Dependency Updates:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL26-R42): Updated `actions/checkout` to version 4, `actions/setup-dotnet` to version 4, and `codecov/codecov-action` to version 4. Updated .NET Core version to 8.0.x.
* [`Instances.Tests.WaitingProgram/Instances.Tests.WaitingProgram.csproj`](diffhunk://#diff-33d58f5aaacf6b34e339df66ff83c87977b165a471885e7242a0cd997bfe4c55L5-R5): Updated target framework to `net8.0`.
* [`Instances.Tests/Instances.Tests.csproj`](diffhunk://#diff-765318d486cd34a1e6d80853bf1bca8615dc0f6d3cf5867726cb43546d0343b0L4-R19): Updated target framework to `net8.0` and several package references to their latest versions.
* [`Instances/Instances.csproj`](diffhunk://#diff-01b85a95c957e2c51b9affbcfcaabb2e713287285f28de316763278cd91a7c22L16-R18): Updated package version to 3.0.1 and added new release notes.

Test Refactoring:
* [`Instances.Tests/Tests.cs`](diffhunk://#diff-ccca5adabe8c3e9bce4e6c20da1c6f679ebd165870089b2f87909f090e7bf0bdL21-R54): Refactored multiple assertions to use `Assert.That` for improved readability and consistency. [[1]](diffhunk://#diff-ccca5adabe8c3e9bce4e6c20da1c6f679ebd165870089b2f87909f090e7bf0bdL21-R54) [[2]](diffhunk://#diff-ccca5adabe8c3e9bce4e6c20da1c6f679ebd165870089b2f87909f090e7bf0bdL66-R66) [[3]](diffhunk://#diff-ccca5adabe8c3e9bce4e6c20da1c6f679ebd165870089b2f87909f090e7bf0bdL78-R78) [[4]](diffhunk://#diff-ccca5adabe8c3e9bce4e6c20da1c6f679ebd165870089b2f87909f090e7bf0bdL90-R90) [[5]](diffhunk://#diff-ccca5adabe8c3e9bce4e6c20da1c6f679ebd165870089b2f87909f090e7bf0bdL106-R106) [[6]](diffhunk://#diff-ccca5adabe8c3e9bce4e6c20da1c6f679ebd165870089b2f87909f090e7bf0bdL115-R115) [[7]](diffhunk://#diff-ccca5adabe8c3e9bce4e6c20da1c6f679ebd165870089b2f87909f090e7bf0bdL126-R125) [[8]](diffhunk://#diff-ccca5adabe8c3e9bce4e6c20da1c6f679ebd165870089b2f87909f090e7bf0bdL138-R137) [[9]](diffhunk://#diff-ccca5adabe8c3e9bce4e6c20da1c6f679ebd165870089b2f87909f090e7bf0bdL147-R147) [[10]](diffhunk://#diff-ccca5adabe8c3e9bce4e6c20da1c6f679ebd165870089b2f87909f090e7bf0bdL167-R167) [[11]](diffhunk://#diff-ccca5adabe8c3e9bce4e6c20da1c6f679ebd165870089b2f87909f090e7bf0bdL180-R179) [[12]](diffhunk://#diff-ccca5adabe8c3e9bce4e6c20da1c6f679ebd165870089b2f87909f090e7bf0bdL192-R194) [[13]](diffhunk://#diff-ccca5adabe8c3e9bce4e6c20da1c6f679ebd165870089b2f87909f090e7bf0bdL207-R209) [[14]](diffhunk://#diff-ccca5adabe8c3e9bce4e6c20da1c6f679ebd165870089b2f87909f090e7bf0bdL221-R223) [[15]](diffhunk://#diff-ccca5adabe8c3e9bce4e6c20da1c6f679ebd165870089b2f87909f090e7bf0bdL234-R238) [[16]](diffhunk://#diff-ccca5adabe8c3e9bce4e6c20da1c6f679ebd165870089b2f87909f090e7bf0bdL249-R253) [[17]](diffhunk://#diff-ccca5adabe8c3e9bce4e6c20da1c6f679ebd165870089b2f87909f090e7bf0bdL264-R268) [[18]](diffhunk://#diff-ccca5adabe8c3e9bce4e6c20da1c6f679ebd165870089b2f87909f090e7bf0bdL281-R283) [[19]](diffhunk://#diff-ccca5adabe8c3e9bce4e6c20da1c6f679ebd165870089b2f87909f090e7bf0bdL296-R295)

These changes ensure that the project dependencies are up-to-date and improve the clarity and maintainability of the test code.