### PR TITLE
Fix the race condition in the cancellation callback.

### DIFF
--- a/Instances/ProcessInstance.cs
+++ b/Instances/ProcessInstance.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -71,9 +72,14 @@ namespace Instances
             {
                 _cancellationTokenRegister = cancellationToken.Register(() =>
                 {
-                    if (!_process.HasExited)
+                    try
                     {
                         _process.Kill();
+                    }
+                    catch (InvalidOperationException )
+                    {
+                        // There is no process associated with this Process object. Ignoring.
+                        
                     }
                 });
             }


### PR DESCRIPTION
### Summary
Fix race condition in cancellation callback in `WaitForExitAsync()`.

### Background
`Process.Kill` throws `InvalidOperationException` if the process has already exited (no underlying OS process).
Earlier attempt to fix this in commit 4edc9d73 added a `HasExited` check. This only lowered probability of failure, but did not remove the race: the process can exit after `HasExited` is checked but before `Kill` executes.

### Problem
Race around `Process.HasExited` + `Process.Kill`, so we still can get the `InvalidOperationException`.

### Fix
Remove the `HasExited` pre-check. Call `_process.Kill()` directly inside `try` and swallow `InvalidOperationException` (process already gone).